### PR TITLE
Make parsing of Obsidian publish text property compatible with Zod boolean property

### DIFF
--- a/packages/astro-loader-obsidian/schemas.ts
+++ b/packages/astro-loader-obsidian/schemas.ts
@@ -7,7 +7,13 @@ export const ObsidianCoreSchema = z.object({
 });
 
 export const ObsidianPublishSchema = z.object({
-  publish: z.boolean().optional(),
+  publish: z.preprocess((val) => {
+    if (typeof val === "string") {
+        if (val.toLowerCase() === "true") return true;
+        if (val.toLowerCase() === "false") return false;
+    }
+    return val;
+  }, z.boolean().optional()),
   permalink: z.string(),
   description: z.string().optional(),
   image: z.string().optional(),


### PR DESCRIPTION
As far as I can tell, Obsidian doesn't offer a true boolean property type so I was getting an error trying to use it with this loader. It's possible that the Publish core plugin sets a true boolean. In any case, this change will make it possible to use a publish text property of "true" or "false". Solution was [found in this comment by @vitorklock.](https://github.com/colinhacks/zod/issues/2985#issuecomment-2230692578)