### PR TITLE
loaders: return on failed render

### DIFF
--- a/packages/astro-loader-obsidian/loaders.ts
+++ b/packages/astro-loader-obsidian/loaders.ts
@@ -130,6 +130,7 @@ export const ObsidianMdLoader: (opts: ObsidianMdLoaderOptions) => Loader = (
           });
         } catch (error: any) {
           logger.error(`Error rendering ${entry}: ${error.message}`);
+          return;
         }
 
         store.set({


### PR DESCRIPTION
I was skimming through the code and noticed what appears to be a missing return. I didn't test this change though it seems reasonable given other early returns in the function.